### PR TITLE
🔧 Customizable Go executable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 include Makefile.*
 
+GO?=go
+
 .PHONY: bin/bindl-dev
 bin/bindl-dev:
-	go build -o bin/bindl -trimpath ./cmd/bindl
+	${GO} build -o bin/bindl -trimpath ./cmd/bindl
 
 # TODO: download from latest release
 bin/bindl:
-	go build -o bin/bindl -trimpath ./cmd/bindl
+	${GO} build -o bin/bindl -trimpath ./cmd/bindl
 
 .PHONY: archy
 archy: bin/archy


### PR DESCRIPTION
Because I'm running this on my 2015 Macbook Pro, and v1.18 (required for Bindl) isn't available through Homebrew yet, so I have to run `go1.18` 😢 

TY for the pair programming @wilsonehusin 