### PR TITLE
🌱 Add "generate" command, move "make" and "ignore"

### DIFF
--- a/command/cli/cli.go
+++ b/command/cli/cli.go
@@ -8,9 +8,8 @@ import (
 
 var All = []*cobra.Command{
 	BindlGet,
-	BindlIgnore,
 	BindlSync,
-	BindlMake,
+	BindlGenerate,
 }
 
 var logDebug bool

--- a/command/cli/generate.go
+++ b/command/cli/generate.go
@@ -1,0 +1,15 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+var BindlGenerate = &cobra.Command{
+	Use:     "generate",
+	Aliases: []string{"gen"},
+	Short:   "Generate project integration files (e.g. Makefile, .gitignore)",
+	Long:    `Generate common setup for projects to have smooth workflow.`,
+}
+
+func init() {
+	BindlGenerate.AddCommand(BindlGenerateIgnore)
+	BindlGenerate.AddCommand(BindlGenerateMake)
+}

--- a/command/cli/generate_ignore.go
+++ b/command/cli/generate_ignore.go
@@ -5,9 +5,9 @@ import (
 	"go.xargs.dev/bindl/command"
 )
 
-var bindlIgnorePath = ".gitignore"
+var bindlGenerateIgnorePath = ".gitignore"
 
-var BindlIgnore = &cobra.Command{
+var BindlGenerateIgnore = &cobra.Command{
 	Use:   "ignore",
 	Short: "Generate ignore file for bindl programs",
 	Long: `Generate ignore file for bindl programs 
@@ -23,10 +23,10 @@ For example, with default output directory "bin":
 
 Supports typical ignore files. e.g. .dockerignore`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return command.UpdateIgnoreFile(defaultConfig, bindlIgnorePath)
+		return command.UpdateIgnoreFile(defaultConfig, bindlGenerateIgnorePath)
 	},
 }
 
 func init() {
-	BindlIgnore.Flags().StringVarP(&bindlIgnorePath, "path", "p", bindlIgnorePath, "path to ignore file")
+	BindlGenerateIgnore.Flags().StringVarP(&bindlGenerateIgnorePath, "path", "p", bindlGenerateIgnorePath, "path to ignore file")
 }

--- a/command/cli/generate_make.go
+++ b/command/cli/generate_make.go
@@ -5,9 +5,9 @@ import (
 	"go.xargs.dev/bindl/command"
 )
 
-var bindlMakefilePath = "Makefile.bindl"
+var bindlGenerateMakefilePath = "Makefile.bindl"
 
-var BindlMake = &cobra.Command{
+var BindlGenerateMake = &cobra.Command{
 	Use:   "make",
 	Short: "Generate Makefile for bindl programs",
 	Long: `Generate Makefile for all programs in lockfile.
@@ -27,10 +27,10 @@ in your other rules. For example:
 
 Calling the imported rules also works on 'make' CLI.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return command.GenerateMakefile(defaultConfig, bindlMakefilePath)
+		return command.GenerateMakefile(defaultConfig, bindlGenerateMakefilePath)
 	},
 }
 
 func init() {
-	BindlMake.Flags().StringVarP(&bindlMakefilePath, "path", "p", bindlMakefilePath, "path to generated Makefile")
+	BindlGenerateMake.Flags().StringVarP(&bindlGenerateMakefilePath, "path", "p", bindlGenerateMakefilePath, "path to generated Makefile")
 }


### PR DESCRIPTION
Putting "generate" style commands together to keep the clutter off
the root command.

Fixes #20 