### PR TITLE
🐛 get command requires at least one argument or --all flag

### DIFF
--- a/cmd/bindl/main.go
+++ b/cmd/bindl/main.go
@@ -20,10 +20,12 @@ import (
 	"os/signal"
 
 	"go.xargs.dev/bindl/command/cli"
+	"go.xargs.dev/bindl/internal"
 )
 
 func main() {
 	if err := run(); err != nil {
+		internal.ErrorMsg(err)
 		os.Exit(1)
 	}
 }
@@ -33,6 +35,11 @@ func run() error {
 	defer cancel()
 
 	cli.Root.AddCommand(versionCmd)
-	err := cli.Root.ExecuteContext(ctx)
-	return err
+
+	// Silence default errors as they don't look noisy,
+	// print error manually in main()
+	cli.Root.SilenceErrors = true
+	cli.Root.SilenceUsage = true
+
+	return cli.Root.ExecuteContext(ctx)
 }

--- a/command/cli/get.go
+++ b/command/cli/get.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"go.xargs.dev/bindl/command"
@@ -27,6 +29,12 @@ var BindlGet = &cobra.Command{
 	Short: "Get local copy of program",
 	Long: `Get downloads the names program, which must already exist in bindl.yaml,
 and ensures the program is ready to be used by setting executable flag.`,
+	PreRunE: func(cmd *cobra.Command, names []string) error {
+		if !bindlGetAll && len(names) == 0 {
+			return fmt.Errorf("program name required but missing: specify program name or use '--all'")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, names []string) error {
 		if bindlGetAll {
 			return command.GetAll(cmd.Context(), defaultConfig)


### PR DESCRIPTION
<!-- Please prefix PR title with an icon, then delete these lines -->
<!-- ✨ (:sparkles:, feature additions) -->
<!-- 🐛 (:bug:, patch and bugfixes) -->
<!-- 📖 (:book:, documentation or proposals) -->
<!-- 🔧 (:wrench:, configuration files) -->
<!-- 🌱 (:seedling:, minor changes, e.g. refactoring or tests) -->

## What this PR does / Why we need it

`bindl get` requires at least one argument when `--all` is not specified. This change will ensure that error is returned to user if no arguments were passed and `--all` was not specified.

## Which issue(s) this PR fixes

Fixes #27 
