### PR TITLE
🔧 Make dev builds with `goreleaser` too

### DIFF
--- a/.bindl-lock.yaml
+++ b/.bindl-lock.yaml
@@ -45,6 +45,29 @@ programs:
       linux: Linux
   url: https://github.com/xargs-dev/archy/releases/download/v{{ .Version }}/{{ .Name }}_{{ .Version }}_{{ .OS }}_{{ .Arch }}.tar.gz
   version: 0.1.2
+- checksum: https://github.com/goreleaser/goreleaser/releases/download/v{{ .Version }}/checksums.txt
+  checksums:
+    goreleaser_Darwin_arm64.tar.gz:
+      _archive: 3349254563781493938c15ea94351e542b32932bfddaff587c5a0bae65e40c94
+      goreleaser: 148af83bc1d992bfdf5a0607ed1337f239fef24ac7fd22ec97083026a25d3dce
+    goreleaser_Darwin_x86_64.tar.gz:
+      _archive: aebb22ab32ddc36002caf3362e2410f1a1487ab098c1f1ac6f5aae59f13f498b
+      goreleaser: 0a801baa89a8a1c8bec1763ee07ffbe84b22defd3284e94d5081d1cbe7ebad8e
+    goreleaser_Linux_arm64.tar.gz:
+      _archive: 8be69f369d8cd80aedbcfb39ba0af8fbb71fa86ee5879e0fcd94075cf17f73a2
+      goreleaser: 8ad2e4bf43079db8e5a17cf011547eda373012da331ea2536c29f15601a1f040
+    goreleaser_Linux_x86_64.tar.gz:
+      _archive: e74934e7571991522324642ac7b032310f04baf192ce2a54db1dc323b97bcd7d
+      goreleaser: 6675d65b87ed168f6c7a981623b3b80a8c1c734197d6e4467cc764f23e843583
+  name: goreleaser
+  overlay:
+    Arch:
+      amd64: x86_64
+    OS:
+      darwin: Darwin
+      linux: Linux
+  url: https://github.com/goreleaser/goreleaser/releases/download/v{{ .Version }}/{{ .Name }}_{{ .OS }}_{{ .Arch }}.tar.gz
+  version: 1.7.0
 - checksum: https://github.com/golangci/golangci-lint/releases/download/v{{ .Version }}/{{ .Name }}-{{ .Version }}-checksums.txt
   checksums:
     golangci-lint-1.45.0-darwin-amd64.tar.gz:
@@ -62,4 +85,4 @@ programs:
   name: golangci-lint
   url: https://github.com/golangci/golangci-lint/releases/download/v{{ .Version }}/{{ .Name }}-{{ .Version }}-{{ .OS }}-{{ .Arch }}.tar.gz
   version: 1.45.0
-updated: "2022-03-19T19:30:30.383766Z"
+updated: "2022-03-24T19:15:27.148810664Z"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 bin/*
 !bin/.keep
 .direnv
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,9 @@ builds:
     main: ./cmd/bindl
     flags:
       - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+    mod_timestamp: '{{ .CommitTimestamp }}'
 sboms:
   - artifacts: archive
 signs:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ bin/bindl:
 	${GO} build -o bin/bindl -trimpath ./cmd/bindl
 
 .PHONY: bin/bindl-dev
-bin/bindl-dev:
-	${GO} build -o bin/bindl -trimpath ./cmd/bindl
+bin/bindl-dev: bin/goreleaser
+	bin/goreleaser build \
+		--output bin/bindl \
+		--single-target \
+		--skip-validate \
+		--rm-dist
 
 include Makefile.*
 

--- a/Makefile.bindl
+++ b/Makefile.bindl
@@ -9,5 +9,8 @@ bin/addlicense: bin/bindl
 bin/archy: bin/bindl
 	bin/bindl get archy
 
+bin/goreleaser: bin/bindl
+	bin/bindl get goreleaser
+
 bin/golangci-lint: bin/bindl
 	bin/bindl get golangci-lint

--- a/bindl.yaml
+++ b/bindl.yaml
@@ -6,17 +6,19 @@ platforms:
     - amd64
     - arm64
 
+_uname: &uname
+  OS: &uname_OS
+    linux: "Linux"
+    darwin: "Darwin"
+  Arch: &uname_Arch
+    amd64: "x86_64"
+
 programs:
   - name: archy
     version: 0.1.2
     provider: url
     path: https://github.com/xargs-dev/archy/releases/download/v{{ .Version }}/{{ .Name }}_{{ .Version }}_{{ .OS }}_{{ .Arch }}.tar.gz
-    overlay:
-      OS:
-        linux: "Linux"
-        darwin: "Darwin"
-      Arch:
-        amd64: "x86_64"
+    overlay: *uname
     checksums:
       _src: https://github.com/xargs-dev/archy/releases/download/v{{ .Version }}/checksums.txt
   - name: addlicense
@@ -25,12 +27,18 @@ programs:
     path: https://github.com/google/addlicense/releases/download/v{{ .Version }}/{{ .Name }}_{{ .Version }}_{{ .OS }}_{{ .Arch }}.tar.gz
     overlay:
       OS:
-        linux: "Linux"
+        <<: *uname_OS
         darwin: "macOS"
-      Arch:
-        amd64: "x86_64"
+      Arch: *uname_Arch
     checksums:
       _src: https://github.com/google/addlicense/releases/download/v{{ .Version }}/checksums.txt
+  - name: goreleaser
+    version: 1.7.0
+    provider: url
+    path: https://github.com/goreleaser/goreleaser/releases/download/v{{ .Version }}/{{ .Name }}_{{ .OS }}_{{ .Arch }}.tar.gz
+    overlay: *uname
+    checksums:
+      _src: https://github.com/goreleaser/goreleaser/releases/download/v{{ .Version }}/checksums.txt
   - name: golangci-lint
     # LINT: Match with version in .golangci.yaml and .github/workflows/go.yaml
     version: 1.45.0

--- a/cmd/bindl/version.go
+++ b/cmd/bindl/version.go
@@ -16,16 +16,16 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"runtime/debug"
 
 	"github.com/spf13/cobra"
+	internalversion "go.xargs.dev/bindl/internal/version"
 )
 
 var (
-	version = "dev"
-	commit  = ""
-	date    = ""
+	version   = ""
+	commit    = ""
+	date      = ""
+	goVersion = ""
 )
 
 var versionCmd = &cobra.Command{
@@ -34,12 +34,16 @@ var versionCmd = &cobra.Command{
 	Run:   printVersion,
 }
 
-func printVersion(*cobra.Command, []string) {
-	fmt.Printf("version: %s\ncommit: %s\ndate: %s\n", version, commit, date)
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		fmt.Printf("unable to retrieve build info")
-		os.Exit(1)
+func init() {
+	if version == "" {
+		version = internalversion.Version()
 	}
-	fmt.Printf("go: %s\n", bi.GoVersion)
+	internalversion.MarkModified(&version)
+	if goVersion == "" {
+		goVersion = internalversion.GoVersion()
+	}
+}
+
+func printVersion(*cobra.Command, []string) {
+	fmt.Printf("version: %s (%s)\ncommit: %s\ndate: %s\n", version, goVersion, commit, date)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Bindl Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"runtime/debug"
+)
+
+var (
+	version   string
+	commit    string
+	date      string
+	goVersion string
+	modified  bool
+)
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		panic("unable to retrieve build info")
+	}
+	version = bi.Main.Version
+	goVersion = bi.GoVersion
+
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			commit = s.Value
+		case "vcs.time":
+			date = s.Value
+		case "vcs.modified":
+			modified = true
+			version = version + "-dirty"
+		default:
+			continue
+		}
+	}
+}
+
+func Version() string {
+	return version
+}
+
+func Commit() string {
+	return commit
+}
+
+func Date() string {
+	return date
+}
+
+func GoVersion() string {
+	return goVersion
+}
+
+func Modified() bool {
+	return modified
+}
+
+func MarkModified(v *string) {
+	if Modified() {
+		*v = *v + "-dirty"
+	}
+}


### PR DESCRIPTION
<!-- Please prefix PR title with an icon, then delete these lines -->
<!-- ✨ (:sparkles:, feature additions) -->
<!-- 🐛 (:bug:, patch and bugfixes) -->
<!-- 📖 (:book:, documentation or proposals) -->
<!-- 🔧 (:wrench:, configuration files) -->
<!-- 🌱 (:seedling:, minor changes, e.g. refactoring or tests) -->

## What this PR does / Why we need it

- Add build reproducibility of CI and ldflags stamping in dev mode ([reference](https://goreleaser.com/customization/build/#reproducible-builds))
- Versions fallback to `debug.BuildInfo` in case of missing `ldflags` on build (mostly in scenarios of imports or `go get`, which aren't officially supported anyway)

## Which issue(s) this PR fixes

<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged) -->

N/A
