### PR TITLE
✨ Parse runtime configuration from environment variable

### DIFF
--- a/command/cli/get.go
+++ b/command/cli/get.go
@@ -15,11 +15,10 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"go.xargs.dev/bindl/command"
+	"go.xargs.dev/bindl/internal"
 )
 
 var BindlGet = &cobra.Command{
@@ -37,7 +36,7 @@ will be selected.`,
 			names,
 			command.Get)
 		if err == nil {
-			fmt.Printf("✨ Programs are downloaded, ensure that %s is in your $PATH to use properly.\n", defaultConfig.BinPathDir)
+			internal.Msgf("✨ Program(s) were downloaded, ensure that %s is in your $PATH to use properly.\n", defaultConfig.BinDir)
 		}
 		return err
 	},

--- a/command/get.go
+++ b/command/get.go
@@ -19,42 +19,50 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog"
 	"go.xargs.dev/bindl/config"
 	"go.xargs.dev/bindl/download"
 	"go.xargs.dev/bindl/internal"
 	"go.xargs.dev/bindl/program"
 )
 
-func symlink(progDir, symlinkPath string, p *program.URLProgram) error {
-	internal.Log().Debug().Str("program", p.PName).Str("progDir", progDir).Msg("symlink program")
+func symlink(binDir, progDir string, p *program.URLProgram) error {
+	relProgDir := filepath.Join(progDir, p.PName)
+	symlinkPath := filepath.Join(binDir, p.PName)
+	internal.Log().Debug().
+		Str("program", p.PName).
+		Dict("symlink", zerolog.Dict().
+			Str("ref", relProgDir).
+			Str("target", symlinkPath)).
+		Msg("symlink program")
 	_ = os.Remove(symlinkPath)
 	return os.Symlink(filepath.Join(progDir, p.PName), symlinkPath)
 }
 
-// Get implements ProgramCommandFunc, therefore needs to be concurrent-safe
+// Get implements ProgramCommandFunc, therefore needs to be concurrent-safe.
 func Get(ctx context.Context, conf *config.Runtime, p *program.URLProgram) error {
-	err := Verify(ctx, conf, p)
-	if err == nil {
-		internal.Log().Debug().Str("program", p.PName).Msg("found existing, skipping")
-		return nil
+	archiveName, err := p.ArchiveName(conf.OS, conf.Arch)
+	if err != nil {
+		return err
+	}
+
+	progDir := filepath.Join(conf.ProgDir, p.Checksums[archiveName].Binaries[p.PName]+"-"+p.PName)
+	if err := Verify(ctx, conf, p); err == nil {
+		// Re-run symlink to renew atime and mtime, so that GNU Make will not rebuild in the future
+		internal.Log().Debug().Str("program", p.PName).Msg("found valid existing, re-linking")
+		return symlink(conf.BinDir, progDir, p)
 	}
 
 	internal.Log().Debug().Err(err).Msg("verification failed")
 
 	// Looks like verify failed, let's assume that the right version exists,
 	// but was symlinked to the wrong one, therefore fix symlink and re-verify
-	archiveName, err := p.ArchiveName(conf.OS, conf.Arch)
-	if err != nil {
-		return err
-	}
-	progDir := filepath.Join(conf.ProgDir, p.Checksums[archiveName].Binaries[p.PName]+"-"+p.PName)
-	fullProgDir := filepath.Join(conf.BinPathDir, progDir)
-	symlinkPath := filepath.Join(conf.BinPathDir, p.PName)
-	if err := symlink(progDir, symlinkPath, p); err != nil {
+	if err := symlink(conf.BinDir, progDir, p); err != nil {
 		internal.Log().Debug().Err(err).Msg("failed symlink, donwloading program")
 	} else {
-		if err = Verify(ctx, conf, p); err == nil {
+		if err := Verify(ctx, conf, p); err == nil {
 			internal.Log().Debug().Str("program", p.PName).Msg("re-linked to appropriate version")
+			// No need to return symlink() here, because we just ran symlink()
 			return nil
 		}
 	}
@@ -72,6 +80,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.URLProgram) error
 	}
 	internal.Log().Debug().Str("program", p.PName).Msg("found binary")
 
+	fullProgDir := filepath.Join(conf.BinDir, progDir)
 	if err = os.MkdirAll(fullProgDir, 0755); err != nil {
 		return err
 	}
@@ -82,5 +91,5 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.URLProgram) error
 	}
 	internal.Log().Debug().Str("output", binPath).Str("program", p.PName).Msg("downloaded")
 
-	return symlink(progDir, symlinkPath, p)
+	return symlink(conf.BinDir, progDir, p)
 }

--- a/command/ignore.go
+++ b/command/ignore.go
@@ -67,23 +67,23 @@ func getNumNewlinesRequired(f *os.File) (int, error) {
 	return 0, nil
 }
 
-func getValidTargets(binPathDir string) map[string]bool {
-	noTrailingSlash := strings.TrimSuffix(binPathDir, "/")
+func getValidTargets(binDir string) map[string]bool {
+	noTrailingSlash := strings.TrimSuffix(binDir, "/")
 	return map[string]bool{
-		filepath.Join(binPathDir, "*"): true,
-		noTrailingSlash + "/":          true,
-		noTrailingSlash:                true,
+		filepath.Join(binDir, "*"): true,
+		noTrailingSlash + "/":      true,
+		noTrailingSlash:            true,
 	}
 }
 
-func getIgnoreEntry(binPathDir string, numPrefixNewlines int) string {
+func getIgnoreEntry(binDir string, numPrefixNewlines int) string {
 	prefix := ""
 	for i := 0; i < numPrefixNewlines; i++ {
 		prefix += "\n"
 	}
 
 	internal.Log().Debug().Int("newlines", numPrefixNewlines).Msg("creating entry to add to file")
-	return prefix + "# Development and tool binaries\n" + filepath.Join(binPathDir, "*") + "\n"
+	return prefix + "# Development and tool binaries\n" + filepath.Join(binDir, "*") + "\n"
 }
 
 func UpdateIgnoreFile(conf *config.Runtime, path string) error {
@@ -95,7 +95,7 @@ func UpdateIgnoreFile(conf *config.Runtime, path string) error {
 	}
 	defer f.Close()
 
-	targets := getValidTargets(conf.BinPathDir)
+	targets := getValidTargets(conf.BinDir)
 
 	n := 0
 	scanner := bufio.NewScanner(f)
@@ -115,6 +115,6 @@ func UpdateIgnoreFile(conf *config.Runtime, path string) error {
 		return err
 	}
 
-	_, err = f.WriteString(getIgnoreEntry(conf.BinPathDir, numNewlinesRequired))
+	_, err = f.WriteString(getIgnoreEntry(conf.BinDir, numNewlinesRequired))
 	return err
 }

--- a/command/ignore_test.go
+++ b/command/ignore_test.go
@@ -25,13 +25,13 @@ import (
 func TestUpdateIgnoreFile(t *testing.T) {
 	testCases := []struct {
 		name         string
-		binPathDir   string
+		binDir       string
 		fileContents string
 		want         string
 	}{
 		{
 			name:         "Empty ignore file",
-			binPathDir:   "bin",
+			binDir:       "bin",
 			fileContents: "",
 			want: `# Development and tool binaries
 bin/*
@@ -39,31 +39,31 @@ bin/*
 		},
 		{
 			name:         "NO ADD: bin/* variation",
-			binPathDir:   "bin/",
+			binDir:       "bin/",
 			fileContents: "bin/*",
 			want:         "bin/*",
 		},
 		{
-			name:         "NO ADD: bin/ variation, binPathDir with trailing slash",
-			binPathDir:   "bin/",
+			name:         "NO ADD: bin/ variation, binDir with trailing slash",
+			binDir:       "bin/",
 			fileContents: "bin/",
 			want:         "bin/",
 		},
 		{
-			name:         "NO ADD: bin/ variation, binPathDir no trailing slash",
-			binPathDir:   "bin",
+			name:         "NO ADD: bin/ variation, binDir no trailing slash",
+			binDir:       "bin",
 			fileContents: "bin/",
 			want:         "bin/",
 		},
 		{
 			name:         "NO ADD: bin variation",
-			binPathDir:   "bin/",
+			binDir:       "bin/",
 			fileContents: "bin",
 			want:         "bin",
 		},
 		{
-			name:       "Ignore entry commented out",
-			binPathDir: "binny",
+			name:   "Ignore entry commented out",
+			binDir: "binny",
 			fileContents: `# binny/*
 secret`,
 			want: `# binny/*
@@ -74,8 +74,8 @@ binny/*
 `,
 		},
 		{
-			name:       "End with newline",
-			binPathDir: "binny",
+			name:   "End with newline",
+			binDir: "binny",
 			fileContents: `secret1
 secret
 `,
@@ -91,7 +91,7 @@ binny/*
 	dir := t.TempDir()
 	for _, tc := range testCases {
 		conf := &config.Runtime{
-			BinPathDir: tc.binPathDir,
+			BinDir: tc.binDir,
 		}
 		f, err := os.CreateTemp(dir, "ignore*")
 		if err != nil {

--- a/command/make.go
+++ b/command/make.go
@@ -23,7 +23,7 @@ import (
 	"go.xargs.dev/bindl/config"
 )
 
-var rawMakefileTmpl = "\n{{ .BinPathDir }}/{{ .Name }}: {{ .BinPathDir }}/bindl\n\t{{ .BinPathDir }}/bindl get {{ .Name }}\n"
+var rawMakefileTmpl = "\n{{ .BinDir }}/{{ .Name }}: {{ .BinDir }}/bindl\n\t{{ .BinDir }}/bindl get {{ .Name }}\n"
 
 var makefileTmpl = template.Must(template.New("makefile").Parse(rawMakefileTmpl))
 
@@ -49,7 +49,7 @@ func GenerateMakefile(conf *config.Runtime, path string) error {
 	}
 
 	m := map[string]string{
-		"BinPathDir": filepath.Base(conf.BinPathDir),
+		"BinDir": filepath.Base(conf.BinDir),
 	}
 
 	for _, prog := range l.Programs {

--- a/command/purge.go
+++ b/command/purge.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Purge(ctx context.Context, conf *config.Runtime, all, dryRun bool) error {
-	progDir := filepath.Join(conf.BinPathDir, conf.ProgDir)
+	progDir := filepath.Join(conf.BinDir, conf.ProgDir)
 	if all {
 		return removeAll(progDir, dryRun)
 	}

--- a/command/verify.go
+++ b/command/verify.go
@@ -28,7 +28,7 @@ import (
 
 // Verify implements ProgramCommandFunc, therefore needs to be concurrent-safe
 func Verify(ctx context.Context, conf *config.Runtime, prog *program.URLProgram) error {
-	binPath := filepath.Join(conf.BinPathDir, prog.PName)
+	binPath := filepath.Join(conf.BinDir, prog.PName)
 	f, err := os.Open(binPath)
 	if err != nil {
 		return fmt.Errorf("opening '%v': %w", binPath, err)

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -15,11 +15,14 @@
 package config
 
 type Runtime struct {
-	Path         string
-	LockfilePath string
-	BinPathDir   string
-	ProgDir      string
+	Path         string `envconfig:"CONFIG"`
+	LockfilePath string `envconfig:"LOCK"`
+	BinDir       string `envconfig:"BIN"`
+	ProgDir      string `envconfig:"PROG"`
 
-	OS   string
-	Arch string
+	OS   string `envconfig:"OS"`
+	Arch string `envconfig:"ARCH"`
+
+	Debug  bool `envconfig:"DEBUG"`
+	Silent bool `envconfig:"SILENT"`
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/fatih/color v1.13.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/cobra v1.4.0
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -30,6 +30,10 @@ func init() {
 
 var Log *zerolog.Logger
 
+func IsSilent() bool {
+	return Log.GetLevel() == zerolog.Disabled
+}
+
 func SetLevel(level string) error {
 	lv, err := zerolog.ParseLevel(strings.ToLower(level))
 	if err != nil {
@@ -38,5 +42,6 @@ func SetLevel(level string) error {
 
 	l := Log.Level(lv)
 	Log = &l
+	Log.Debug().Str("lvl", level).Send()
 	return nil
 }

--- a/internal/message.go
+++ b/internal/message.go
@@ -19,10 +19,19 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"go.xargs.dev/bindl/internal/log"
 )
 
 var errHeader = color.HiRedString("ERROR")
 
 func ErrorMsg(err error) {
-	fmt.Fprintf(os.Stderr, "%s - %s\n", errHeader, err.Error())
+	if !log.IsSilent() {
+		fmt.Fprintf(os.Stderr, "%s - %s\n", errHeader, err.Error())
+	}
+}
+
+func Msgf(msg string, vars ...any) {
+	if !log.IsSilent() {
+		fmt.Fprintf(os.Stderr, msg, vars...)
+	}
 }


### PR DESCRIPTION
<!-- Please prefix PR title with an icon, then delete these lines -->
<!-- ✨ (:sparkles:, feature additions) -->
<!-- 🐛 (:bug:, patch and bugfixes) -->
<!-- 📖 (:book:, documentation or proposals) -->
<!-- 🔧 (:wrench:, configuration files) -->
<!-- 🌱 (:seedling:, minor changes, e.g. refactoring or tests) -->

## What this PR does / Why we need it

Allow configuration of `config.Runtime` to be done from environment variable. This adds flexibility for contexts when running in automation.

Additionally, `internal.Msgf` and `internal.ErrorMsg` honors silent flags (based on zerolog configuration).

## Which issue(s) this PR fixes

<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged) -->

Fixes #8 
