### PR TITLE
✨ Cache download responses

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,5 @@ PATH_add $(go env GOBIN)
 PATH_add bin/
 
 layout go
+
+export BINDL_USE_CACHE=true

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@
 # Development and tool binaries
 bin/*
 !bin/.keep
+tmp/*
+!tmp/.keep
 .direnv
 dist/

--- a/command/cli/cli.go
+++ b/command/cli/cli.go
@@ -59,6 +59,8 @@ var conf = &config.Runtime{
 	BinDir:       "./bin",
 	ProgDir:      ".bindl/programs",
 
+	UseCache: false,
+
 	Debug:  false,
 	Silent: false,
 
@@ -71,6 +73,8 @@ func init() {
 	Root.PersistentFlags().StringVarP(&conf.LockfilePath, "lock", "l", conf.LockfilePath, "path to lockfile")
 	Root.PersistentFlags().StringVarP(&conf.BinDir, "bin", "b", conf.BinDir, "directory in PATH to add binaries")
 	Root.PersistentFlags().StringVar(&conf.ProgDir, "prog", conf.ProgDir, "directory to save real binary content")
+
+	Root.PersistentFlags().BoolVar(&conf.UseCache, "cache", conf.UseCache, "read and write cache")
 
 	Root.PersistentFlags().BoolVarP(&conf.Silent, "silent", "s", conf.Silent, "silence logs")
 	Root.PersistentFlags().BoolVar(&conf.Debug, "debug", conf.Debug, "show debug logs")

--- a/command/get.go
+++ b/command/get.go
@@ -73,7 +73,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 	// Looks like verify failed, let's assume that the right version exists,
 	// but was symlinked to the wrong one, therefore fix symlink and re-verify
 	if err := symlink(conf.BinDir, progDir, p); err != nil {
-		internal.Log().Debug().Err(err).Msg("failed symlink, donwloading program")
+		internal.Log().Debug().Err(err).Msg("failed symlink, downloading program")
 	} else {
 		if err := Verify(ctx, conf, p); err == nil {
 			internal.Log().Debug().Str("program", p.Name).Msg("re-linked to appropriate version")
@@ -84,7 +84,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 
 	internal.Log().Debug().Err(err).Msg("verification failed after fixing symlink, redownloading")
 
-	a, err := p.DownloadArchive(ctx, &download.HTTP{}, conf.OS, conf.Arch)
+	a, err := p.DownloadArchive(ctx, &download.HTTP{UseCache: conf.UseCache}, conf.OS, conf.Arch)
 	if err != nil {
 		return err
 	}

--- a/command/sync.go
+++ b/command/sync.go
@@ -51,7 +51,7 @@ func Sync(ctx context.Context, conf *config.Runtime, writeToStdout bool) error {
 			defer wg.Done()
 
 			internal.Log().Info().Str("program", prog.Name).Msg("building program spec")
-			p, err := prog.Lock(ctx, c.Platforms)
+			p, err := prog.Lock(ctx, c.Platforms, conf.UseCache)
 			if err != nil {
 				internal.Log().Err(err).Str("program", prog.Name).Msg("parsing configuration")
 				hasError = true

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -26,6 +26,8 @@ type Runtime struct {
 	OS   string `envconfig:"OS"`
 	Arch string `envconfig:"ARCH"`
 
+	UseCache bool `envconfig:"USE_CACHE"`
+
 	Debug  bool `envconfig:"DEBUG"`
 	Silent bool `envconfig:"SILENT"`
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bindl-dev/bindl
 go 1.18
 
 require (
+	github.com/bindl-dev/httpcache v0.0.0-20220410163408-6f3ea26e5589
 	github.com/fatih/color v1.13.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rs/zerolog v1.26.1
@@ -11,9 +12,11 @@ require (
 )
 
 require (
+	github.com/google/btree v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/peterbourgon/diskv/v3 v3.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bindl-dev/httpcache v0.0.0-20220410163408-6f3ea26e5589 h1:BCjCrbWefjpBNmaQp/ieyY4vNQ+HbmgKIHVVKZ0T+hA=
+github.com/bindl-dev/httpcache v0.0.0-20220410163408-6f3ea26e5589/go.mod h1:z9HbYisQj78o+Ixay6eIyBtv9nJ7WB+HLHYxc/tvOkM=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -5,6 +7,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
@@ -15,6 +20,8 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
+github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=

--- a/program/lock.go
+++ b/program/lock.go
@@ -61,7 +61,7 @@ func NewLock(c *Config) (*Lock, error) {
 // TOFU: Trust on first use -- should only be run first time a program was added to
 // the lockfile. Collecting binary checksums by extracting archives.
 // TODO: Use the values presented in SBOM when available.
-func (p *Lock) collectBinaryChecksum(ctx context.Context, platforms map[string][]string) error {
+func (p *Lock) collectBinaryChecksum(ctx context.Context, platforms map[string][]string, useCache bool) error {
 	var wg sync.WaitGroup
 
 	hasError := false
@@ -72,7 +72,7 @@ func (p *Lock) collectBinaryChecksum(ctx context.Context, platforms map[string][
 			go func(os, arch string) {
 				defer wg.Done()
 
-				a, err := p.DownloadArchive(ctx, &download.HTTP{}, os, arch)
+				a, err := p.DownloadArchive(ctx, &download.HTTP{UseCache: useCache}, os, arch)
 				if err != nil {
 					internal.ErrorMsg(fmt.Errorf("downloading archive for '%s' in %s/%s: %w", p.Name, os, arch, err))
 					return

--- a/program/program_online_test.go
+++ b/program/program_online_test.go
@@ -36,7 +36,7 @@ func TestIntegrationConvertProgramConfigURLProviderToURL(t *testing.T) {
 	u, err := c.Lock(context.Background(), map[string][]string{
 		"linux":  []string{"amd64"},
 		"darwin": []string{"arm64"},
-	})
+	}, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Please prefix PR title with an icon, then delete these lines -->
<!-- ✨ (:sparkles:, feature additions) -->
<!-- 🐛 (:bug:, patch and bugfixes) -->
<!-- 📖 (:book:, documentation or proposals) -->
<!-- 🔧 (:wrench:, configuration files) -->
<!-- 🌱 (:seedling:, minor changes, e.g. refactoring or tests) -->

## What this PR does / Why we need it

Reducing network calls on downloads to speed up user experience. Ironically, this increases disk usage and perhaps adding another thing to be considered in building the solution for #52.

That said, I think this might require some hardening (the cached files are literally HTTP response and therefore items like `checksum.txt` can be seen transparently) thus the feature is toggle-able and disabled by default.

- [x] cache HTTP requests
- [ ] `bindl purge cache` / Low priority, and I think I'd rather decide on #52 first before adding more code that relies on the path

## Which issue(s) this PR fixes

<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged) -->

N/A — spontaneous development.
