### PR TITLE
🔧 Unattended release signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags: [ '*' ]
 
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ signs:
     - '--output-certificate=${certificate}'
     - '--output-signature=${signature}'
     - '${artifact}'
-  artifacts: checksum
+  artifacts: all
   output: true
 archives:
   - replacements:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ signs:
     - '--output-certificate=${certificate}'
     - '--output-signature=${signature}'
     - '${artifact}'
-  artifacts: all
+  artifacts: checksum
   output: true
 archives:
   - replacements:


### PR DESCRIPTION
<!-- Please prefix PR title with an icon, then delete these lines -->
<!-- ✨ (:sparkles:, feature additions) -->
<!-- 🐛 (:bug:, patch and bugfixes) -->
<!-- 📖 (:book:, documentation or proposals) -->
<!-- 🔧 (:wrench:, configuration files) -->
<!-- 🌱 (:seedling:, minor changes, e.g. refactoring or tests) -->

## What this PR does / Why we need it

At the moment, releases require someone to watch the logs and click on Sigstore OAuth link to verify identity. I'm looking around other projects and seem like don't go through the same workflow, and noticed that the difference is only on token permissions.

This also adds signatures for binary releases because, why not? With [sigstore/cosign](https://github.com/sigstore/cosign) releases signing the binaries _and_ checksum, there might be a future where we can skip `checksums.txt` altogether if binary signatures are provided.

## Which issue(s) this PR fixes

<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged) -->

N/A
