### PR TITLE
🌱 Use maximum verbosity for errors in command/get.go

### DIFF
--- a/command/get.go
+++ b/command/get.go
@@ -75,9 +75,8 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 	if err := Verify(ctx, conf, p); err == nil {
 		// Re-run symlink to renew atime and mtime, so that GNU Make will not rebuild in the future
 		internal.Log().Debug().Str("program", p.Name).Msg("found valid existing, re-linking")
-		if err := symlink(conf.BinDir, progDir, p); err != nil {
-			return fmt.Errorf("symlink %s: %w", progDir, err)
-		}
+		// symLink already returns context in the error
+		return symlink(conf.BinDir, progDir, p)
 	}
 
 	internal.Log().Debug().Err(err).Msg("verification failed")

--- a/command/get.go
+++ b/command/get.go
@@ -68,7 +68,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 
 	checksum, ok := p.Checksums[archiveName]
 	if !ok {
-		return fmt.Errorf("failed to find %s in p.Checksums", archiveName)
+		return fmt.Errorf("unrecognized checksum reference '%s'", archiveName)
 	}
 
 	progDir := filepath.Join(conf.ProgDir, checksum.Binary+"-"+p.Name)

--- a/command/get.go
+++ b/command/get.go
@@ -111,7 +111,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 
 	fullProgDir := filepath.Join(conf.BinDir, progDir)
 	if err := os.MkdirAll(fullProgDir, 0755); err != nil {
-		return fmt.Errorf("make dir with parents %s: %w", fullProgDir, err)
+		return fmt.Errorf("ensuring directory existence '%s': %w", fullProgDir, err)
 	}
 
 	binPath := filepath.Join(fullProgDir, p.Name)

--- a/command/get.go
+++ b/command/get.go
@@ -71,12 +71,12 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 		return fmt.Errorf("failed to find %s in p.Checksums", archiveName)
 	}
 
-	progDir := filepath.Join(conf.ProgDir, p.Checksums[archiveName].Binary+"-"+p.Name)
+	progDir := filepath.Join(conf.ProgDir, checksum.Binary+"-"+p.Name)
 	if err := Verify(ctx, conf, p); err == nil {
 		// Re-run symlink to renew atime and mtime, so that GNU Make will not rebuild in the future
 		internal.Log().Debug().Str("program", p.Name).Msg("found valid existing, re-linking")
 		if err := symlink(conf.BinDir, progDir, p); err != nil {
-			return fmt.Errof("symlink %s: %w", progDir, err)
+			return fmt.Errorf("symlink %s: %w", progDir, err)
 		}
 	}
 

--- a/command/get.go
+++ b/command/get.go
@@ -111,7 +111,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 
 	fullProgDir := filepath.Join(conf.BinDir, progDir)
 	if err := os.MkdirAll(fullProgDir, 0755); err != nil {
-		return fmt.Errorf("make dir with parents %s: %w", err)
+		return fmt.Errorf("make dir with parents %s: %w", fullProgDir, err)
 	}
 
 	binPath := filepath.Join(fullProgDir, p.Name)

--- a/command/get.go
+++ b/command/get.go
@@ -116,7 +116,7 @@ func Get(ctx context.Context, conf *config.Runtime, p *program.Lock) error {
 
 	binPath := filepath.Join(fullProgDir, p.Name)
 	if err := os.WriteFile(binPath, bin, 0755); err != nil {
-		return fmt.Errorf("write file %s: %w", binPath, err)
+		return fmt.Errorf("write file '%s': %w", binPath, err)
 	}
 
 	internal.Log().Debug().Str("output", binPath).Str("program", p.Name).Msg("downloaded")


### PR DESCRIPTION
## What this PR does / Why we need it

If a failure occurs in `command/get.go`, the errors now make it extremely obvious what was happening.

Also, a few minor cleanups.

## Which issue(s) this PR fixes

* #72 
