### PR TITLE
✨ Support GZip without Tarball

### DIFF
--- a/program/archive.go
+++ b/program/archive.go
@@ -30,6 +30,7 @@ type Archive struct {
 const (
 	archiveTarSuffix   = ".tar"
 	archiveTarGzSuffix = ".tar.gz"
+	archiveGzSuffix    = ".gz"
 	archiveZipSuffix   = ".zip"
 )
 
@@ -75,6 +76,8 @@ func (a *Archive) extractBinaryNoChecksum(binaryName string) ([]byte, error) {
 		err = untar(&buf, r, binaryName)
 	case strings.HasSuffix(a.Name, archiveTarGzSuffix):
 		err = untargz(&buf, r, binaryName)
+	case strings.HasSuffix(a.Name, archiveGzSuffix):
+		err = ungz(&buf, r, binaryName)
 	default:
 		// assume currently downloaded file is the binary
 		data = a.Data

--- a/program/archive_deflate.go
+++ b/program/archive_deflate.go
@@ -82,3 +82,14 @@ func untargz(w io.Writer, rawTarGz io.Reader, binaryName string) error {
 
 	return untar(w, gzReader, binaryName)
 }
+
+func ungz(w io.Writer, rawGz io.Reader, binaryName string) error {
+	gzReader, err := gzip.NewReader(rawGz)
+	if err != nil {
+		return err
+	}
+	defer gzReader.Close()
+
+	_, err = io.Copy(w, gzReader)
+	return err
+}


### PR DESCRIPTION
## What this PR does / Why we need it

Support GZip archive decompression without it being a Tarball-GZip combination.

## Which issue(s) this PR fixes

Fixes #78
